### PR TITLE
Fix downloading assets & more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+GUI.exe
+LauncherConfig.ini
+Options.ini
+logs/
+.minecraft/
+.minecraft_files/
+.lunarclient_files/
+scripts/__pycache__/

--- a/LCFilesInstaller.ps1
+++ b/LCFilesInstaller.ps1
@@ -4,20 +4,22 @@ $Version = cat "$env:Temp\Version.txt" | Select-Object -First 1
 $Version = $Version.Trim("version: ")
 $GameVersion = $args[0]
 $params = @{
-  "hwid"=""
+  "hwid"="0";
+  "hwid_private"="0";
   "os"="win32";
   "arch"="x64";
   "launcher_version"="$Version";
   "version"="$GameVersion";
   "branch"="master";
-  "launch_type"="ONLINE";
-  "classifier"="";
+  "launch_type"="0";
+  "classifier"="0";
 }
-$Index = iwr "https://api.lunarclientprod.com/launcher/launch" -Method POST -Body ($params|ConvertTo-Json) -ContentType "application/json"
-$Files=($Index.Content | ConvertFrom-Json).launchTypeData.artifacts
-$Licenses=($Index.Content | ConvertFrom-Json).licenses
-$JRE=($Index.Content | ConvertFrom-Json).jre.download.url
-$JRE_Name=($Index.Content | ConvertFrom-Json).jre.executablePathInArchive[0]
+$Index = iwr "https://api.lunarclientprod.com/launcher/launch" -Method POST -Body ($params|ConvertTo-Json) -ContentType "application/json" -OutFile "$env:Temp\Index.txt"
+$Index = cat "$env:Temp\index.txt"
+$Files=($Index | ConvertFrom-Json).launchTypeData.artifacts
+$Licenses=($Index | ConvertFrom-Json).licenses
+$JRE=($Index | ConvertFrom-Json).jre.download.url
+$JRE_Name=($Index | ConvertFrom-Json).jre.executablePathInArchive[0]
 
 $null = New-Item -Path ".lunarclient_files" -ItemType "Directory"
 $null = New-Item -Path ".lunarclient_files\licenses" -Type "Directory"
@@ -26,21 +28,20 @@ $null = New-Item -Path ".lunarclient_files\jre" -Type "Directory"
 cls
 
 Write-Output "Getting Licenses..."
-curl.exe -# -L -o ".lunarclient_files\licenses\ReplayMod.md" $Licenses[0].url
-curl.exe -# -L -o ".lunarclient_files\licenses\Blur.md" $Licenses[1].url
+foreach ($file in $Licenses) {
+  curl.exe -# -L -o ".lunarclient_files\licenses\$($file.file)" $file.url
+}
 Write-Output "Downloading LC ($GameVersion)..."
-Write-Output "Getting LC Jars..."
-curl.exe -# -L -o ".lunarclient_files\offline\$GameVersion\vpatcher-prod.jar" $Files[0].url
-curl.exe -# -L -o ".lunarclient_files\offline\$GameVersion\lunar-prod-optifine.jar" $Files[1].url
-curl.exe -# -L -o ".lunarclient_files\offline\$GameVersion\lunar-libs.jar" $Files[2].url
-curl.exe -# -L -o ".lunarclient_files\offline\$GameVersion\lunar-assets-prod-1-optifine.jar" $Files[3].url
-curl.exe -# -L -o ".lunarclient_files\offline\$GameVersion\lunar-assets-prod-2-optifine.jar" $Files[4].url
-curl.exe -# -L -o ".lunarclient_files\offline\$GameVersion\lunar-assets-prod-3-optifine.jar" $Files[5].url
-Write-Output "Getting Natives..."
-curl.exe -# -L -o ".lunarclient_files\offline\$GameVersion\natives-win-x64.zip" $Files[6].url
-Expand-Archive -Path ".lunarclient_files\offline\$GameVersion\natives-win-x64.zip" -DestinationPath ".lunarclient_files\offline\$GameVersion\natives" -Force
-Write-Output "Getting OptiFine..."
-curl.exe -# -L -o ".lunarclient_files\offline\$GameVersion\OptiFine.jar" $Files[7].url
+Write-Output "Getting LC Jars, Natives & Optifine..."
+foreach ($file in $Files) {
+  if ($file.name.EndsWith(".jar")) {
+    curl.exe -# -L -o ".lunarclient_files\offline\$GameVersion\$($file.name)" $file.url
+  }
+  if ($file.name.EndsWith(".zip")) {
+    curl.exe -# -L -o ".lunarclient_files\offline\$GameVersion\$($file.name)" $file.url
+    Expand-Archive -Path ".lunarclient_files\offline\$GameVersion\$($file.name)" -DestinationPath ".lunarclient_files\offline\$GameVersion\natives" -Force
+  }
+}
 
 if (!(Test-Path -LiteralPath ".lunarclient_files\jre\$JRE_Name")){
 Remove-Item -Path ".lunarclient_files\jre" -Force -Recurse | Out-Null

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # Portaluna
-**Note: It seems Lunar has changed how they receive JSON responses and preventing LC Assets from being downloaded via the PowerShell Script.
-Repository will be remain archived for the moment.**  
 
 An alternative launcher for Lunar Client which is aimed at portability and functionality.   
 


### PR DESCRIPTION
# Changes:
<details>
<summary>Fix downloading assets</summary>
    A new property (hwid_private) was added, and no fields can blank.
</details>
<details>
<summary>Use foreach instead of repeated curl commands</summary>
Very self explanatory.

Example:
    
    curl.exe -# -L -o ".lunarclient_files\licenses\ReplayMod.md" $Licenses[0].url
    curl.exe -# -L -o ".lunarclient_files\licenses\Blur.md" $Licenses[1].url
    
to
    
    foreach ($file in $Licenses) {
      curl.exe -# -L -o ".lunarclient_files\licenses\$($file.file)" $file.url
    }

(the above downloads **all** licenses, not just replaymod and blur)
</details>
<details>
<summary>Add a patch for GGOS & other custom OS'</summary>
    1. Save the output of $Index to a file in the Temp folder
    <br>
    2. Read the file and overwrite $Index with it
    <br>
    3. Parse it
    <br>
    4. Done! 👍
</details>